### PR TITLE
Update NVivo.py

### DIFF
--- a/NVivo.py
+++ b/NVivo.py
@@ -862,11 +862,11 @@ def Normalise(args):
                     nvivoNodeReference.c.CreatedDate,
                     nvivoNodeReference.c.ModifiedBy,
                     nvivoNodeReference.c.ModifiedDate
-                ] + [
+                ] + ([
                     nvivoNodeReference.c.StartText,
                     nvivoNodeReference.c.LengthText
                 ] if args.mac else [
-                ]).where(and_(
+                ])).where(and_(
                     #nvivoNodeReference.c.ReferenceTypeId == literal_column('0'),
                     nvivoItem.c.Id == nvivoNodeReference.c.Node_Item_Id,
                     nvivoItem.c.TypeId == literal_column(NVivo.ItemType.Node),


### PR DESCRIPTION
When runningn "NormaliseNVP.py", an error happens because of "incorrect syntax".
In the File "NVivo.py" from line 865 to line 869, there should be corrected as:
([
nvivoNodeReference.c.StartText,
nvivoNodeReference.c.LengthText
] if args.mac else [
])